### PR TITLE
Fixed 'kerl active' on MacOSX

### DIFF
--- a/kerl
+++ b/kerl
@@ -391,7 +391,7 @@ do_active()
 {
     if [ -n "$_KERL_SAVED_PATH" ]; then
         echo "The current active installation is:"
-        echo `echo $PATH | cut -d ":" -f 1 | head -c -4`
+        echo `echo $PATH | cut -d ":" -f 1 | sed 's/\(.*\)..../\1/'`
         return 0
     else
         echo "No Erlang/OTP kerl installation is currently active"


### PR DESCRIPTION
Hi,

I noticed that you use 'head -c -4' command but minus sign is gnu specific. head command on bsd and mac will fail with "head: illegal byte count -- -4". I replaced head with sed and now 'kerl active' should work on any os.

Regards,
Konrad
